### PR TITLE
Fix composer.json and add CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,3 +10,15 @@ steps:
       docker-compose#v3.7.0:
         config: "$DOCKER_COMPOSE_FILE"
         run: composer
+
+  - label: ":git: Lint Commits"
+    command: npx commitlint --from origin/HEAD --to HEAD --verbose
+    branches: "!main !dependabot/*"
+    timeout_in_minutes: 5
+    plugins:
+      improbable-eng/metahook:
+        post_checkout: git fetch origin main
+      docker-compose#v3.7.0:
+        config: "$DOCKER_COMPOSE_FILE"
+        dependencies: false
+        run: commitlint

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,12 @@
+env:
+  DOCKER_COMPOSE_FILE: "docker-compose.yml"
+
+steps:
+  - label: ":composer: Composer Validate"
+    command: composer validate --strict
+    branches: "!main"
+    timeout_in_minutes: 5
+    plugins:
+      docker-compose#v3.7.0:
+        config: "$DOCKER_COMPOSE_FILE"
+        run: composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax = docker/dockerfile:1.2
+
+FROM node:alpine as commitlint
+
+RUN apk add git
+
+RUN mkdir /app
+
+RUN cd /app
+
+WORKDIR /app
+
+RUN npm install @marketplacer/commitlint-config
+
+CMD npx commitlint --from origin/HEAD --to HEAD --verbose

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,16 @@
+const { generateCommitlintConfig } = require("@marketplacer/commitlint-config");
+
+/** Permissible scopes for commits which present tangible change to end users.
+ *  New scopes may be added as their own commit, and should be discussed to
+ *  confirm it is a reasonable addition. All scopes should have a description
+ *  supplied.
+ *
+ *  Try to keep this list in alphabetical order.
+ */
+const externalFacingScopes = [];
+
+/** Collection of tuples specifying commit type, and permitted scopes for the
+ *  commit type */
+const typesRequiringScopes = [];
+
+module.exports = generateCommitlintConfig({ typesRequiringScopes });

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "marketplacer/magento2-plugin-seller-api",
     "description": "Package of API definitions and basic implementation for Marketplacer Sellers",
     "type": "magento2-module",
-    "version": "2.0.0",
     "license": "proprietary",
     "require": {
         "marketplacer/magento2-plugin-base": "^2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Package of API definitions and basic implementation for Marketplacer Sellers",
     "type": "magento2-module",
     "version": "2.0.0",
+    "license": "proprietary",
     "require": {
         "marketplacer/magento2-plugin-base": "^2.0.0"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.4'
+services:
+  composer:
+    image: composer
+    volumes:
+      - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,11 @@ services:
     image: composer
     volumes:
       - ./:/app
+  commitlint:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      target: commitlint
+    volumes:
+    - ./.git:/app/.git
+    - ./commitlint.config.js:/app/commitlint.config.js


### PR DESCRIPTION
The composer.json file had omitted and superfluous fields.
We also were not validating the composer.json so added this to CI.
Also added commitlint to ensure commit messages meet standard.

<!-- MANDATORY DATA -->
The following sections are required to be completed before merging your PR. It ensures we are following our release process and meeting our auditability requirements. PLEASE ADD MORE CONTEXT WHERE APPLICABLE. If you would like to learn more have a read of https://app.tettra.co/teams/marketplacer/pages/system-acquisition-and-development-policy and https://app.tettra.co/teams/marketplacer/pages/threat-modelling


**Release Checklist:**
<!-- tick the box to show you thought about it, but give more info if you made changes. -->
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.
