### PR TITLE
fix: fix multishipping functionality

### DIFF
--- a/Model/Order/SellerDataPreparer.php
+++ b/Model/Order/SellerDataPreparer.php
@@ -5,10 +5,11 @@ namespace Marketplacer\SellerApi\Model\Order;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
 use Magento\Sales\Model\AbstractModel as SalesAbstractModel;
 use Magento\Sales\Model\Order\Invoice\Item as InvoiceItem;
 use Magento\Sales\Model\Order\Shipment\Item as ShipmentItem;
+use Magento\Quote\Model\Quote\Address\Item as AddressItem;
 use Marketplacer\SellerApi\Api\SellerRepositoryInterface;
 use Marketplacer\SellerApi\Api\Data\OrderItemInterface;
 use Marketplacer\SellerApi\Api\SellerAttributeRetrieverInterface;
@@ -113,7 +114,7 @@ class SellerDataPreparer
     }
 
     /**
-     * @param QuoteItem[] $quoteItems
+     * @param AbstractItem[] $quoteItems
      * @return array
      * @throws LocalizedException
      */
@@ -130,11 +131,11 @@ class SellerDataPreparer
     }
 
     /**
-     * @param QuoteItem $quoteItem
+     * @param AbstractItem $quoteItem
      * @return mixed
      * @throws LocalizedException
      */
-    public function getSellerIdByQuoteItem(QuoteItem $quoteItem)
+    public function getSellerIdByQuoteItem(AbstractItem $quoteItem)
     {
         $sellerAttributeCode = $this->sellerAttributeRetriever->getAttributeCode();
         return $quoteItem->getProduct()->getData($sellerAttributeCode);
@@ -186,6 +187,9 @@ class SellerDataPreparer
     public function getSellerIdBySalesItem($salesItem)
     {
         $orderItem = $salesItem;
+        if ($salesItem instanceof AddressItem) {
+            return null;
+        }
         if ($salesItem instanceof InvoiceItem || $salesItem instanceof ShipmentItem) {
             $orderItem = $salesItem->getOrderItem();
         }
@@ -199,6 +203,9 @@ class SellerDataPreparer
     public function getSellerNameBySalesItem($salesItem)
     {
         $orderItem = $salesItem;
+        if ($salesItem instanceof AddressItem) {
+            return null;
+        }
         if ($salesItem instanceof InvoiceItem || $salesItem instanceof ShipmentItem) {
             $orderItem = $salesItem->getOrderItem();
         }
@@ -212,6 +219,9 @@ class SellerDataPreparer
     public function getSellerBusinessNumberBySalesItem($salesItem)
     {
         $orderItem = $salesItem;
+        if ($salesItem instanceof AddressItem) {
+            return null;
+        }
         if ($salesItem instanceof InvoiceItem || $salesItem instanceof ShipmentItem) {
             $orderItem = $salesItem->getOrderItem();
         }

--- a/Test/Unit/Model/Order/SellerDataPreparerTest.php
+++ b/Test/Unit/Model/Order/SellerDataPreparerTest.php
@@ -203,7 +203,7 @@ class SellerDataPreparerTest extends TestCase
 
     public function testGetSellerNamesBySalesItems()
     {
-        $resulSellerNames = [
+        $resultSellerNames = [
             5 => 'Test Invoice Seller 1',
             10 => 'Test Shipment Seller 2',
             20 => 'Test Order Seller 4',
@@ -245,10 +245,12 @@ class SellerDataPreparerTest extends TestCase
             ->withConsecutive([OrderItemInterface::SELLER_ID], [OrderItemInterface::SELLER_NAME])
             ->willReturnOnConsecutiveCalls(20, 'Test Order Seller 4');
 
+        $addressItemMock = $this->createMock(\Magento\Quote\Model\Quote\Address\Item::class);
+
         $this->assertEquals(
-            $resulSellerNames,
+            $resultSellerNames,
             $this->sellerDataPreparer->getSellerNamesBySalesItems(
-                [$invoiceItemMock, $shipmentItemMock, $orderItemMock3, $orderItemMock4]
+                [$invoiceItemMock, $shipmentItemMock, $orderItemMock3, $orderItemMock4, $addressItemMock]
             )
         );
     }
@@ -297,10 +299,15 @@ class SellerDataPreparerTest extends TestCase
             ->withConsecutive([OrderItemInterface::SELLER_ID], [OrderItemInterface::SELLER_BUSINESS_NUMBER])
             ->willReturnOnConsecutiveCalls(20, 'Test Order ABN 4');
 
+        $addressItemMock = $this->createMock(\Magento\Quote\Model\Quote\Address\Item::class);
+        $addressItemMock
+            ->expects($this->never())
+            ->method('getData');
+
         $this->assertEquals(
             $resulSellerNames,
             $this->sellerDataPreparer->getSellerBusinessNumbersBySalesItems(
-                [$invoiceItemMock, $shipmentItemMock, $orderItemMock3, $orderItemMock4]
+                [$invoiceItemMock, $shipmentItemMock, $orderItemMock3, $orderItemMock4, $addressItemMock]
             )
         );
     }


### PR DESCRIPTION
During the Adobe QA process a bug with the multishipping functionality was discovered.
This change resolves the issue.

**Release Checklist:**
<!-- tick the box to show you thought about it, but give more info if you made changes. -->
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.